### PR TITLE
FIX:AttributeError: module 'google.generativeai' has no attribute 'Client'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ celerybeat.pid
 .env
 .envrc
 .venv
+.idea
 env/
 venv/
 ENV/

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
-import google.generativeai as genai
+from google import genai
 # -----------------------------------------------------------------------
 # 0. 配置
 # -----------------------------------------------------------------------


### PR DESCRIPTION
The project declares google-genai in requirements.txt, and the code initializes the client using gemini_client = genai.Client(). According to the latest genai code specifications, dependencies should be imported using 'from google import genai'."